### PR TITLE
Implement basic integration skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# entegrasyon
+# Entegrasyon
+
+Bu proje, PHP 8.x kullanarak pazaryeri siparişlerinin senkronizasyonu ve kargo entegrasyonlarını hedefleyen basit bir REST API iskeletidir.
+
+## Kurulum
+
+1. PHP 8 ve MySQL kurulu olmalıdır.
+2. `composer install` komutunu çalıştırarak bağımlılıkları yükleyin.
+3. `config/config.php` dosyasındaki veritabanı ayarlarını düzenleyin.
+4. `database.sql` dosyasındaki tabloları oluşturun.
+
+## Kullanım
+
+- `public/index.php` dosyası API için giriş noktasıdır.
+- `cron/fetch_orders.php` dosyası, pazaryerlerinden sipariş çekmek için çalıştırılabilir.
+
+Bu iskelet proje geliştirmeye açıktır. Servis sınıflarındaki `TODO` kısımları doldurarak entegrasyonları tamamlayabilirsiniz.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "entegrasyon/entegrasyon",
+    "description": "E-commerce integration skeleton",
+    "type": "project",
+    "require": {
+        "php": ">=8.0",
+        "firebase/php-jwt": "^6.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'db' => [
+        'host' => 'localhost',
+        'dbname' => 'entegrasyon',
+        'user' => 'root',
+        'pass' => ''
+    ],
+    'api_token' => 'CHANGE_ME'
+];

--- a/cron/fetch_orders.php
+++ b/cron/fetch_orders.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use App\Services\{TrendyolOrderService, HepsiburadaOrderService, PazaramaOrderService, WooOrderService};
+
+$services = [
+    new TrendyolOrderService(),
+    new HepsiburadaOrderService(),
+    new PazaramaOrderService(),
+    new WooOrderService()
+];
+
+foreach ($services as $service) {
+    $orders = $service->fetchOrders();
+    // TODO: save orders to DB
+}

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS marketplaces (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(50) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS accounts (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_id INT,
+    name VARCHAR(100),
+    api_key VARCHAR(255),
+    token VARCHAR(255),
+    FOREIGN KEY (marketplace_id) REFERENCES marketplaces(id)
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_id INT,
+    external_order_id VARCHAR(100),
+    status VARCHAR(50),
+    shipping_name VARCHAR(100),
+    total_price DECIMAL(10,2),
+    items_json JSON,
+    shipping_json JSON,
+    created_at DATETIME,
+    sync_date DATETIME,
+    FOREIGN KEY (marketplace_id) REFERENCES marketplaces(id)
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    order_id INT,
+    product_name VARCHAR(255),
+    quantity INT,
+    price DECIMAL(10,2),
+    FOREIGN KEY (order_id) REFERENCES orders(id)
+);
+
+CREATE TABLE IF NOT EXISTS shipping_labels (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    order_id INT,
+    barcode VARCHAR(100),
+    label_pdf VARCHAR(255),
+    created_at DATETIME,
+    FOREIGN KEY (order_id) REFERENCES orders(id)
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50),
+    password VARCHAR(255),
+    role VARCHAR(50)
+);
+
+CREATE TABLE IF NOT EXISTS logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    message TEXT,
+    created_at DATETIME
+);

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use App\Controllers\OrderController;
+
+$config = require __DIR__ . '/../config/config.php';
+
+$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$method = $_SERVER['REQUEST_METHOD'];
+
+$controller = new OrderController();
+
+switch ($uri) {
+    case '/orders':
+        if ($method === 'GET') {
+            $controller->list();
+        }
+        break;
+    case '/order':
+        if ($method === 'GET') {
+            $id = $_GET['id'] ?? null;
+            $controller->show($id);
+        }
+        break;
+    default:
+        http_response_code(404);
+        echo json_encode(['error' => 'Not Found']);
+}

--- a/src/Controllers/OrderController.php
+++ b/src/Controllers/OrderController.php
@@ -1,0 +1,45 @@
+<?php
+namespace App\Controllers;
+
+use App\Services\OrderService;
+
+class OrderController
+{
+    private OrderService $service;
+
+    public function __construct()
+    {
+        $this->service = new OrderService();
+
+        $config = require __DIR__ . '/../../config/config.php';
+        $token = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+        if ($token !== 'Bearer ' . $config['api_token']) {
+            http_response_code(401);
+            echo json_encode(['error' => 'Unauthorized']);
+            exit;
+        }
+    }
+
+    public function list(): void
+    {
+        header('Content-Type: application/json');
+        echo json_encode($this->service->getAll());
+    }
+
+    public function show(?string $id): void
+    {
+        if ($id === null) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Missing id']);
+            return;
+        }
+        header('Content-Type: application/json');
+        $order = $this->service->getById($id);
+        if ($order) {
+            echo json_encode($order);
+        } else {
+            http_response_code(404);
+            echo json_encode(['error' => 'Not found']);
+        }
+    }
+}

--- a/src/Helpers/DB.php
+++ b/src/Helpers/DB.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Helpers;
+
+use PDO;
+
+class DB
+{
+    private static ?PDO $instance = null;
+
+    public static function getConnection(): PDO
+    {
+        if (self::$instance === null) {
+            $config = require __DIR__ . '/../../config/config.php';
+            $db = $config['db'];
+            $dsn = "mysql:host={$db['host']};dbname={$db['dbname']};charset=utf8mb4";
+            self::$instance = new PDO($dsn, $db['user'], $db['pass']);
+            self::$instance->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        }
+        return self::$instance;
+    }
+}

--- a/src/Services/HepsiburadaOrderService.php
+++ b/src/Services/HepsiburadaOrderService.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Services;
+
+class HepsiburadaOrderService implements MarketplaceOrderInterface
+{
+    public function fetchOrders(): array
+    {
+        // TODO: Implement API call to Hepsiburada
+        return [];
+    }
+}

--- a/src/Services/MarketplaceOrderInterface.php
+++ b/src/Services/MarketplaceOrderInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Services;
+
+interface MarketplaceOrderInterface
+{
+    public function fetchOrders(): array;
+}

--- a/src/Services/OrderService.php
+++ b/src/Services/OrderService.php
@@ -1,0 +1,29 @@
+<?php
+namespace App\Services;
+
+use App\Helpers\DB;
+use PDO;
+
+class OrderService
+{
+    private PDO $db;
+
+    public function __construct()
+    {
+        $this->db = DB::getConnection();
+    }
+
+    public function getAll(): array
+    {
+        $stmt = $this->db->query('SELECT * FROM orders ORDER BY created_at DESC');
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function getById(string $id): ?array
+    {
+        $stmt = $this->db->prepare('SELECT * FROM orders WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $order = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $order ?: null;
+    }
+}

--- a/src/Services/PazaramaOrderService.php
+++ b/src/Services/PazaramaOrderService.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Services;
+
+class PazaramaOrderService implements MarketplaceOrderInterface
+{
+    public function fetchOrders(): array
+    {
+        // TODO: Implement API call to Pazarama
+        return [];
+    }
+}

--- a/src/Services/Shipping/ShippingServiceInterface.php
+++ b/src/Services/Shipping/ShippingServiceInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Services\Shipping;
+
+interface ShippingServiceInterface
+{
+    public function createLabel(array $order): array;
+}

--- a/src/Services/Shipping/YurticiShippingService.php
+++ b/src/Services/Shipping/YurticiShippingService.php
@@ -1,0 +1,15 @@
+<?php
+namespace App\Services\Shipping;
+
+use App\Services\Shipping\ShippingServiceInterface;
+
+class YurticiShippingService implements ShippingServiceInterface
+{
+    public function createLabel(array $order): array
+    {
+        // TODO: call Yurtici API
+        return [
+            'barcode' => '1234567890'
+        ];
+    }
+}

--- a/src/Services/TrendyolOrderService.php
+++ b/src/Services/TrendyolOrderService.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Services;
+
+class TrendyolOrderService implements MarketplaceOrderInterface
+{
+    public function fetchOrders(): array
+    {
+        // TODO: Implement API call to Trendyol
+        return [];
+    }
+}

--- a/src/Services/WooOrderService.php
+++ b/src/Services/WooOrderService.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Services;
+
+class WooOrderService implements MarketplaceOrderInterface
+{
+    public function fetchOrders(): array
+    {
+        // TODO: Implement API call to WooCommerce
+        return [];
+    }
+}


### PR DESCRIPTION
## Summary
- set up Composer and autoloading
- add database helper and config
- create order controller and service with token auth
- stub marketplace order services and cron task
- include shipping service interface and example implementation
- provide sample database schema and README instructions

## Testing
- `php -l public/index.php` *(fails: `php` not found)*
- `composer --version` *(fails: `composer` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b245d2248322a19fc095b8f3bfe4