### PR TITLE
Add simple Tabler frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# entegrasyon
+# Entegrasyon
+
+Bu proje, PHP 8.x kullanarak pazaryeri siparişlerinin senkronizasyonu ve kargo entegrasyonlarını hedefleyen basit bir REST API iskeletidir.
+
+## Kurulum
+
+1. PHP 8 ve MySQL kurulu olmalıdır.
+2. `composer install` komutunu çalıştırarak bağımlılıkları yükleyin.
+3. `config/config.php` dosyasındaki veritabanı ayarlarını düzenleyin.
+4. `database.sql` dosyasındaki tabloları oluşturun.
+
+## Kullanım
+
+- `public/index.php` dosyası API için giriş noktasıdır.
+- `cron/fetch_orders.php` dosyası, pazaryerlerinden sipariş çekmek ve veritabanına kaydetmek için çalıştırılabilir.
+- `POST /order/label` endpointi, bir sipariş için Yurtici Kargo etiketi oluşturur. `id` parametresi gereklidir.
+- `public/orders.html` dosyası, Tabler.io tabanlı basit bir arayüz sağlar. `API_TOKEN` sabitini güncelleyerek siparişleri görüntüleyebilir ve kargo fişi oluşturabilirsiniz.
+
+Bu iskelet proje geliştirmeye açıktır. Servis sınıflarındaki `TODO` kısımları doldurarak entegrasyonları tamamlayabilirsiniz.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "entegrasyon/entegrasyon",
+    "description": "E-commerce integration skeleton",
+    "type": "project",
+    "require": {
+        "php": ">=8.0",
+        "firebase/php-jwt": "^6.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'db' => [
+        'host' => 'localhost',
+        'dbname' => 'entegrasyon',
+        'user' => 'root',
+        'pass' => ''
+    ],
+    'api_token' => 'CHANGE_ME'
+];

--- a/cron/fetch_orders.php
+++ b/cron/fetch_orders.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use App\Services\{TrendyolOrderService, HepsiburadaOrderService, PazaramaOrderService, WooOrderService, OrderService};
+
+$services = [
+    new TrendyolOrderService(),
+    new HepsiburadaOrderService(),
+    new PazaramaOrderService(),
+    new WooOrderService()
+];
+
+$orderService = new OrderService();
+
+foreach ($services as $service) {
+    $orders = $service->fetchOrders();
+    foreach ($orders as $order) {
+        $orderService->save($order);
+    }
+}

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS marketplaces (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(50) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS accounts (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_id INT,
+    name VARCHAR(100),
+    api_key VARCHAR(255),
+    token VARCHAR(255),
+    FOREIGN KEY (marketplace_id) REFERENCES marketplaces(id)
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_id INT,
+    external_order_id VARCHAR(100),
+    status VARCHAR(50),
+    shipping_name VARCHAR(100),
+    total_price DECIMAL(10,2),
+    items_json JSON,
+    shipping_json JSON,
+    created_at DATETIME,
+    sync_date DATETIME,
+    FOREIGN KEY (marketplace_id) REFERENCES marketplaces(id)
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    order_id INT,
+    product_name VARCHAR(255),
+    quantity INT,
+    price DECIMAL(10,2),
+    FOREIGN KEY (order_id) REFERENCES orders(id)
+);
+
+CREATE TABLE IF NOT EXISTS shipping_labels (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    order_id INT,
+    barcode VARCHAR(100),
+    label_pdf VARCHAR(255),
+    created_at DATETIME,
+    FOREIGN KEY (order_id) REFERENCES orders(id)
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50),
+    password VARCHAR(255),
+    role VARCHAR(50)
+);
+
+CREATE TABLE IF NOT EXISTS logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    message TEXT,
+    created_at DATETIME
+);

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use App\Controllers\OrderController;
+
+$config = require __DIR__ . '/../config/config.php';
+
+$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$method = $_SERVER['REQUEST_METHOD'];
+
+$controller = new OrderController();
+
+switch ($uri) {
+    case '/orders':
+        if ($method === 'GET') {
+            $controller->list();
+        }
+        break;
+    case '/order':
+        if ($method === 'GET') {
+            $id = $_GET['id'] ?? null;
+            $controller->show($id);
+        }
+        break;
+    case '/order/label':
+        if ($method === 'POST') {
+            $id = $_POST['id'] ?? null;
+            $controller->createLabel($id);
+        }
+        break;
+    default:
+        http_response_code(404);
+        echo json_encode(['error' => 'Not Found']);
+}

--- a/public/orders.html
+++ b/public/orders.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="tr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Entegrasyon - Siparişler</title>
+  <link href="https://cdn.jsdelivr.net/npm/tabler@1.0.0-beta19/dist/css/tabler.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/tabler@1.0.0-beta19/dist/js/tabler.min.js" defer></script>
+</head>
+<body>
+  <div class="page">
+    <header class="navbar navbar-expand-md navbar-light d-print-none">
+      <div class="container-xl">
+        <h1 class="navbar-brand navbar-brand-autodark">Entegrasyon</h1>
+      </div>
+    </header>
+    <div class="page-wrapper">
+      <div class="page-body">
+        <div class="container-xl">
+          <h2 class="page-title">Siparişler</h2>
+          <div class="card">
+            <table class="table card-table table-vcenter">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Pazar Yeri ID</th>
+                  <th>Durum</th>
+                  <th>Alıcı</th>
+                  <th>Tutar</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody id="orders-body"></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<script>
+const API_TOKEN = 'CHANGE_ME';
+async function loadOrders() {
+  const res = await fetch('/orders', { headers: { 'Authorization': 'Bearer ' + API_TOKEN } });
+  const orders = await res.json();
+  const tbody = document.getElementById('orders-body');
+  tbody.innerHTML = '';
+  orders.forEach(o => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${o.id}</td>
+      <td>${o.external_order_id}</td>
+      <td>${o.status}</td>
+      <td>${o.shipping_name}</td>
+      <td>${o.total_price}</td>
+      <td><button class="btn btn-sm btn-primary" onclick="createLabel(${o.id})">Kargo Fişi</button></td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+async function createLabel(id) {
+  const formData = new FormData();
+  formData.append('id', id);
+  const res = await fetch('/order/label', {
+    method: 'POST',
+    headers: { 'Authorization': 'Bearer ' + API_TOKEN },
+    body: formData
+  });
+  const data = await res.json();
+  if (res.ok) {
+    alert('Barkod: ' + data.barcode);
+  } else {
+    alert('Hata: ' + data.error);
+  }
+}
+loadOrders();
+</script>
+</body>
+</html>

--- a/src/Controllers/OrderController.php
+++ b/src/Controllers/OrderController.php
@@ -1,0 +1,69 @@
+<?php
+namespace App\Controllers;
+
+use App\Services\OrderService;
+use App\Services\Shipping\YurticiShippingService;
+
+class OrderController
+{
+    private OrderService $service;
+
+    public function __construct()
+    {
+        $this->service = new OrderService();
+
+        $config = require __DIR__ . '/../../config/config.php';
+        $token = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+        if ($token !== 'Bearer ' . $config['api_token']) {
+            http_response_code(401);
+            echo json_encode(['error' => 'Unauthorized']);
+            exit;
+        }
+    }
+
+    public function list(): void
+    {
+        header('Content-Type: application/json');
+        echo json_encode($this->service->getAll());
+    }
+
+    public function show(?string $id): void
+    {
+        if ($id === null) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Missing id']);
+            return;
+        }
+        header('Content-Type: application/json');
+        $order = $this->service->getById($id);
+        if ($order) {
+            echo json_encode($order);
+        } else {
+            http_response_code(404);
+            echo json_encode(['error' => 'Not found']);
+        }
+    }
+
+    public function createLabel(?string $id): void
+    {
+        if ($id === null) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Missing id']);
+            return;
+        }
+
+        $order = $this->service->getById($id);
+        if (!$order) {
+            http_response_code(404);
+            echo json_encode(['error' => 'Order not found']);
+            return;
+        }
+
+        $shippingService = new YurticiShippingService();
+        $label = $shippingService->createLabel($order);
+        $this->service->createShippingLabel($order['id'], $label);
+
+        header('Content-Type: application/json');
+        echo json_encode($label);
+    }
+}

--- a/src/Helpers/DB.php
+++ b/src/Helpers/DB.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Helpers;
+
+use PDO;
+
+class DB
+{
+    private static ?PDO $instance = null;
+
+    public static function getConnection(): PDO
+    {
+        if (self::$instance === null) {
+            $config = require __DIR__ . '/../../config/config.php';
+            $db = $config['db'];
+            $dsn = "mysql:host={$db['host']};dbname={$db['dbname']};charset=utf8mb4";
+            self::$instance = new PDO($dsn, $db['user'], $db['pass']);
+            self::$instance->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        }
+        return self::$instance;
+    }
+}

--- a/src/Services/HepsiburadaOrderService.php
+++ b/src/Services/HepsiburadaOrderService.php
@@ -1,0 +1,25 @@
+<?php
+namespace App\Services;
+
+class HepsiburadaOrderService implements MarketplaceOrderInterface
+{
+    public function fetchOrders(): array
+    {
+        // TODO: Replace with real Hepsiburada API integration
+        return [
+            [
+                'marketplace_id' => 2,
+                'external_order_id' => 'H456',
+                'status' => 'created',
+                'shipping_name' => 'Mehmet Kara',
+                'total_price' => 200,
+                'items_json' => [
+                    ['name' => 'HB Urun', 'qty' => 2, 'price' => 100]
+                ],
+                'shipping_json' => [
+                    'address' => 'Ankara'
+                ]
+            ]
+        ];
+    }
+}

--- a/src/Services/MarketplaceOrderInterface.php
+++ b/src/Services/MarketplaceOrderInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Services;
+
+interface MarketplaceOrderInterface
+{
+    public function fetchOrders(): array;
+}

--- a/src/Services/OrderService.php
+++ b/src/Services/OrderService.php
@@ -1,0 +1,80 @@
+<?php
+namespace App\Services;
+
+use App\Helpers\DB;
+use PDO;
+
+class OrderService
+{
+    private PDO $db;
+
+    public function __construct()
+    {
+        $this->db = DB::getConnection();
+    }
+
+    public function getAll(): array
+    {
+        $stmt = $this->db->query('SELECT * FROM orders ORDER BY created_at DESC');
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function getById(string $id): ?array
+    {
+        $stmt = $this->db->prepare('SELECT * FROM orders WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $order = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $order ?: null;
+    }
+
+    public function save(array $order): void
+    {
+        $stmt = $this->db->prepare(
+            'SELECT id FROM orders WHERE external_order_id = :external_id AND marketplace_id = :marketplace_id'
+        );
+        $stmt->execute([
+            'external_id' => $order['external_order_id'],
+            'marketplace_id' => $order['marketplace_id']
+        ]);
+        $existingId = $stmt->fetchColumn();
+
+        if ($existingId) {
+            $update = $this->db->prepare(
+                'UPDATE orders SET status = :status, shipping_name = :shipping_name, total_price = :total_price, items_json = :items_json, shipping_json = :shipping_json, sync_date = NOW() WHERE id = :id'
+            );
+            $update->execute([
+                'status' => $order['status'],
+                'shipping_name' => $order['shipping_name'],
+                'total_price' => $order['total_price'],
+                'items_json' => json_encode($order['items_json']),
+                'shipping_json' => json_encode($order['shipping_json']),
+                'id' => $existingId
+            ]);
+        } else {
+            $insert = $this->db->prepare(
+                'INSERT INTO orders (marketplace_id, external_order_id, status, shipping_name, total_price, items_json, shipping_json, created_at, sync_date) VALUES (:marketplace_id, :external_id, :status, :shipping_name, :total_price, :items_json, :shipping_json, NOW(), NOW())'
+            );
+            $insert->execute([
+                'marketplace_id' => $order['marketplace_id'],
+                'external_id' => $order['external_order_id'],
+                'status' => $order['status'],
+                'shipping_name' => $order['shipping_name'],
+                'total_price' => $order['total_price'],
+                'items_json' => json_encode($order['items_json']),
+                'shipping_json' => json_encode($order['shipping_json'])
+            ]);
+        }
+    }
+
+    public function createShippingLabel(int $orderId, array $data): void
+    {
+        $stmt = $this->db->prepare(
+            'INSERT INTO shipping_labels (order_id, barcode, label_pdf, created_at) VALUES (:order_id, :barcode, :label_pdf, NOW())'
+        );
+        $stmt->execute([
+            'order_id' => $orderId,
+            'barcode' => $data['barcode'],
+            'label_pdf' => $data['label_pdf'] ?? null
+        ]);
+    }
+}

--- a/src/Services/PazaramaOrderService.php
+++ b/src/Services/PazaramaOrderService.php
@@ -1,0 +1,25 @@
+<?php
+namespace App\Services;
+
+class PazaramaOrderService implements MarketplaceOrderInterface
+{
+    public function fetchOrders(): array
+    {
+        // TODO: Replace with real Pazarama API integration
+        return [
+            [
+                'marketplace_id' => 3,
+                'external_order_id' => 'P789',
+                'status' => 'created',
+                'shipping_name' => 'Ayse Demir',
+                'total_price' => 150,
+                'items_json' => [
+                    ['name' => 'Pazarama Urun', 'qty' => 1, 'price' => 150]
+                ],
+                'shipping_json' => [
+                    'address' => 'Izmir'
+                ]
+            ]
+        ];
+    }
+}

--- a/src/Services/Shipping/ShippingServiceInterface.php
+++ b/src/Services/Shipping/ShippingServiceInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Services\Shipping;
+
+interface ShippingServiceInterface
+{
+    public function createLabel(array $order): array;
+}

--- a/src/Services/Shipping/YurticiShippingService.php
+++ b/src/Services/Shipping/YurticiShippingService.php
@@ -1,0 +1,19 @@
+<?php
+namespace App\Services\Shipping;
+
+use App\Services\Shipping\ShippingServiceInterface;
+
+class YurticiShippingService implements ShippingServiceInterface
+{
+    public function createLabel(array $order): array
+    {
+        // TODO: Replace with real Yurti\u00e7i Kargo API integration
+        $barcode = 'YP' . rand(100000000, 999999999);
+
+        // In real scenario you would generate PDF here
+        return [
+            'barcode' => $barcode,
+            'label_pdf' => null
+        ];
+    }
+}

--- a/src/Services/TrendyolOrderService.php
+++ b/src/Services/TrendyolOrderService.php
@@ -1,0 +1,26 @@
+<?php
+namespace App\Services;
+
+class TrendyolOrderService implements MarketplaceOrderInterface
+{
+    public function fetchOrders(): array
+    {
+        // TODO: Replace with real Trendyol API integration
+        return [
+            [
+                'marketplace_id' => 1,
+                'external_order_id' => 'T123',
+                'status' => 'created',
+                'shipping_name' => 'Ahmet Yilmaz',
+                'total_price' => 100.5,
+                'items_json' => [
+                    ['name' => 'Urun A', 'qty' => 1, 'price' => 50.25],
+                    ['name' => 'Urun B', 'qty' => 1, 'price' => 50.25]
+                ],
+                'shipping_json' => [
+                    'address' => 'Istanbul'
+                ]
+            ]
+        ];
+    }
+}

--- a/src/Services/WooOrderService.php
+++ b/src/Services/WooOrderService.php
@@ -1,0 +1,25 @@
+<?php
+namespace App\Services;
+
+class WooOrderService implements MarketplaceOrderInterface
+{
+    public function fetchOrders(): array
+    {
+        // TODO: Replace with real WooCommerce API integration
+        return [
+            [
+                'marketplace_id' => 4,
+                'external_order_id' => 'W321',
+                'status' => 'created',
+                'shipping_name' => 'Fatma Kaya',
+                'total_price' => 75,
+                'items_json' => [
+                    ['name' => 'Woo Urun', 'qty' => 3, 'price' => 25]
+                ],
+                'shipping_json' => [
+                    'address' => 'Bursa'
+                ]
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- document the new `public/orders.html` page
- add an HTML page using Tabler to view orders and create labels

## Testing
- `php -l public/index.php` *(fails: `php` not found)*
- `composer --version` *(fails: `composer` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b245d2248322a19fc095b8f3bfe4